### PR TITLE
New support to add an optional default assignee queue

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -28,6 +28,11 @@ teams:
       - martincousido
       - marinarv
       - greobasco
+
+  - name: default
+    assignees:
+      - juanperezperri
+      - srialMule
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 skipKeywords:
   - wip

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ through teams member list, once the team is determined the reviewers list is use
 assign a reviewer, team's names are used as key because of that each one must be different, each team has its own reviewers queue.
 
 ## Installation
-
 To install auto-assign you need to follow the next steps.
 
 1. Go to GitHub Settings/Developer settings and create a new GitHub App.
@@ -21,6 +20,9 @@ To install auto-assign you need to follow the next steps.
 1. Install your GitHub App to your repository.
 
 ## Structure of auto_assign.yml
+You can set a default list of assignees that will be applied when someone that is not a member of any team 
+creates a PR/Issue, you just need to create a team called default that team just need a list of assignees
+just as in the following example.
 
 ```bash
 teams:
@@ -28,7 +30,6 @@ teams:
     members:
       - github_user_name_1
       - github_user_name_2
-    
     assignees:
       - github_user_name_1
       - github_user_name_2
@@ -37,7 +38,16 @@ teams:
     members:
       - github_user_name_3
       - github_user_name_4
-    
     assignees:
       - github_user_name_5
+
+  - name: default
+    assignees:
+      - github_user_name_1
+      - github_user_name_3
 ```
+
+## Testing
+If you want to test something without affect the queue order for your repo you can add a property scope: dev
+to your auto_assign.yml that will forced the app to use a memory queue instead of the database, take in mind 
+that every PR and Issue that you create using this property will be really assign.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install auto-assign you need to follow the next steps.
 
 ## Structure of auto_assign.yml
 You can set a default list of assignees that will be applied when someone that is not a member of any team 
-creates a PR/Issue, you just need to create a team called default that team just need a list of assignees
+creates a PR/Issue, In order to do that, you just need to create a team called `default`. That team just need a list of `assignees`
 just as in the following example.
 
 ```bash
@@ -48,6 +48,6 @@ teams:
 ```
 
 ## Testing
-If you want to test something without affect the queue order for your repo you can add a property scope: dev
-to your auto_assign.yml that will forced the app to use a memory queue instead of the database, take in mind 
-that every PR and Issue that you create using this property will be really assign.
+If you want to test something without affecting the queue order for your repo you can add a property `scope: dev`
+to your `auto_assign.yml`. This will force the app to use a memory queue instead of the database.
+WARNING: Keep in mind that every PR and Issue that you create using this property will be really assign.

--- a/src/assigner.ts
+++ b/src/assigner.ts
@@ -41,7 +41,7 @@ export class Assigner {
             this.context.log('there is no candidate to review')
             return
         }
-        console.log((isPR? "The PR" : "The issue") + " created by " + owner + " will be assign to: " + reviewer)
+        console.log(`The ${isPR ? "PR" : "issue"} created by ${owner} will be assign to: ${reviewer}`)
         // get user
         this.context.github.graphql (userQuery, {
             member: reviewer

--- a/src/assigner.ts
+++ b/src/assigner.ts
@@ -41,8 +41,7 @@ export class Assigner {
             this.context.log('there is no candidate to review')
             return
         }
-        console.log("candidate to be assigned: " + reviewer)
-
+        console.log((isPR? "The PR" : "The issue") + " created by " + owner + " will be assign to: " + reviewer)
         // get user
         this.context.github.graphql (userQuery, {
             member: reviewer

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -44,18 +44,19 @@ export class Handler {
     let ownerConfigTeam = getTeam(owner, config.teams)
     let dbTeamQueue: QueueDB | null = await db.getTeamQueue(repo, ownerConfigTeam.name)
 
-    console.log(dbTeamQueue? dbTeamQueue : "dbQueue not exist yet for the team: " + ownerConfigTeam? ownerConfigTeam.name: "unknown team")
+    console.log(dbTeamQueue? dbTeamQueue : "Not exist register in database yet for " + owner +
+        "'s team: " + (ownerConfigTeam? ownerConfigTeam.name: "unknown team"))
     var teamAssigneesQueue: Queue<string> = this.syncTeamConfig(ownerConfigTeam.assignees, dbTeamQueue? dbTeamQueue.data : null);
     let listAssignees = isPR ? payload.pull_request.assignees : payload.issue.assignees
     let oneAssignee = isPR ? payload.pull_request.assignee : payload.issue.assignee
     if (listAssignees.length > 0) {
       // move assignees to the bottom of the queue and dont assign new
       listAssignees.forEach((assignee: { login: string; }) => {
-        console.log("move to back: " + assignee.login)
+        console.log("Move to back to the queue due a manual assignation: " + assignee.login)
         teamAssigneesQueue.toBack(assignee.login);
       });
     } else if (oneAssignee && oneAssignee.length > 0) {
-      console.log("move to back: " + oneAssignee.login)
+      console.log("Move to back to the queue due a manual assignation: " + oneAssignee.login)
       teamAssigneesQueue.toBack(oneAssignee.login)
     } else {
       // check and assign new
@@ -83,14 +84,14 @@ export class Handler {
     const configSet = new Set(configTeamAssignees)
     configTeamAssignees.forEach(member => {
       if (!dbSet.has(member)) {
-        console.log("Team member ${member} added! ")
+        console.log("Team member " + member + " added! ")
         queue.append(member)
       }
     })
 
     dbSet.forEach(member => {
       if (!configSet.has(member)) {
-        console.log("Team member ${member} removed! ")
+        console.log("Team member " + member + " removed! ")
         queue.remove(member)
       }
     })

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ export function getTeam(member: string, teams: Team[]): Team | null{
       teamTarget = team;
     }
 
-    if (team.members.includes(member)) {
+    if (team.members && team.members.includes(member)) {
       teamTarget = team;
       break;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,12 +20,15 @@ export function getOwner(context: Context,isPR: Boolean): string{
 
 export function getTeam(member: string, teams: Team[]): Team | null{
   let teamTarget: Team
+  let defaultTeam: Team
   for (var i = 0, len = teams.length; i < len; i++) {
-    let team: Team = teams[i]
-    if (team.members.includes(member)){
-      teamTarget = teams[i]
-      break
+    var team = teams[i];
+    if (team.name === 'default') {
+      defaultTeam = team;
+    } else if (team.members.includes(member)) {
+      teamTarget = teams[i];
+      break;
     }
   }
-  return teamTarget? teamTarget : null
+  return teamTarget? teamTarget : defaultTeam
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,15 +20,17 @@ export function getOwner(context: Context,isPR: Boolean): string{
 
 export function getTeam(member: string, teams: Team[]): Team | null{
   let teamTarget: Team
-  let defaultTeam: Team
-  for (var i = 0, len = teams.length; i < len; i++) {
-    var team = teams[i];
+
+  for (let team of teams) {
     if (team.name === 'default') {
-      defaultTeam = team;
-    } else if (team.members.includes(member)) {
-      teamTarget = teams[i];
+      teamTarget = team;
+    }
+
+    if (team.members.includes(member)) {
+      teamTarget = team;
       break;
     }
   }
-  return teamTarget? teamTarget : defaultTeam
+
+  return teamTarget;
 }


### PR DESCRIPTION
With these changes auto assign is able to handle a reserved team name called: "default" it allows us to handle PR/Issues created by a member that doesn't belong to any config team, this feature is completely optional

some logs improvement to make them more friendly 